### PR TITLE
Reserved ticket counts after a cancelled registration

### DIFF
--- a/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
+++ b/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
@@ -329,7 +329,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * @return bool
      * @throws EE_Error
      */
-    protected function _release_reserved_ticket(EE_Ticket $ticket, $quantity = 1)
+    protected function _release_reserved_ticket(EE_Ticket $ticket, $quantity = 0)
     {
         if (self::debug) {
             echo '<br /> . . . ticket->ID: ' . $ticket->ID();


### PR DESCRIPTION
**Thanks for your pull request!**

Please answer the following questions in order to expedite its acceptance.

#### What problem does this work solve, or what benefit does it have?
Reserved ticket counts after a cancelled registration

#### Why do you think these changes are needed in Event Espresso core instead of being put in an add-on? 

> Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on

#### Why do you think this is the best implementation?
For example if the user cancel the registration of 3 tickets, the _release_reserved_ticket function call decrease_reserved($quantity) function (from EE_Ticket.class.php file) 3 times with the default value of $quantity=1 and remove 3 tickets reservation, So the default value of $quantity must be 0,  because that will happen one time ($quantity=3) via \EE_Ticket::decrease_reserved() when \EE_Ticket::_decrease_reserved_for_datetimes is called

#### Does this include unit tests? Or how can it be tested?
> Automated tests not only demonstrate the code works, but also help in ongoing maintenance. So pull requests with automated tests are preferred.

## Please indicate
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
